### PR TITLE
Fix: escape column content so that Receiver's email address is shown.

### DIFF
--- a/WPML_Email_Log_List.php
+++ b/WPML_Email_Log_List.php
@@ -131,7 +131,6 @@ class Email_Logging_ListTable extends WP_List_Table {
 			case 'mail_id':
 			case 'timestamp':
 			case 'receiver':
-				debug( $item );
 			case 'subject':
 			case 'message':
 			case 'headers':


### PR DESCRIPTION
As described in #13, version 1.3 of WP Email Logs shows email logs like this:

![screenshot](https://cloud.githubusercontent.com/assets/45068/4104145/d28f1996-3181-11e4-9050-3531cfbe5cf9.png)

After the modifications in this PR, email log entries look like the screenshot below:

![screenshot](https://cloud.githubusercontent.com/assets/45068/4104245/cbc8bace-3184-11e4-9cd6-3cb14ede6f08.png)
