### PR TITLE
FIx error with strict DISTINCT requirements in mysql8

### DIFF
--- a/lib/vendor/brandonwamboldt/wp-orm/src/Admin/ListTable.php
+++ b/lib/vendor/brandonwamboldt/wp-orm/src/Admin/ListTable.php
@@ -334,7 +334,7 @@ abstract class ListTable
         global $wpdb, $wp_locale;
 
         $months = $wpdb->get_results($wpdb->prepare("
-            SELECT DISTINCT YEAR(post_date) AS year, MONTH(post_date) AS month
+            SELECT DISTINCT YEAR(post_date) AS year, MONTH(post_date) AS month, post_date
             FROM $wpdb->posts
             WHERE post_type = %s
             ORDER BY post_date DESC

--- a/src/inc/class-wp-list-table.php
+++ b/src/inc/class-wp-list-table.php
@@ -382,7 +382,7 @@ class WP_List_Table {
         global $wpdb, $wp_locale;
 
         $months = $wpdb->get_results( $wpdb->prepare( "
-			SELECT DISTINCT YEAR( post_date ) AS year, MONTH( post_date ) AS month
+			SELECT DISTINCT YEAR( post_date ) AS year, MONTH( post_date ) AS month, post_date
 			FROM $wpdb->posts
 			WHERE post_type = %s
 			ORDER BY post_date DESC


### PR DESCRIPTION
There are issues with both the (unmaintained) wp-orm dependency and the plugin code when used with mysql8:

`Expression #1 of ORDER BY clause is not in SELECT list, references column 'defaultdb.www_posts.post_date' which is not in SELECT list; this is incompatible with DISTINCT`