### PR TITLE
Add support for encoded subjects

### DIFF
--- a/src/Renderer/Column/SubjectColumn.php
+++ b/src/Renderer/Column/SubjectColumn.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace No3x\WPML\Renderer\Column;
+
+use No3x\WPML\Renderer\Exception\ColumnDoesntExistException;
+
+class SubjectColumn implements IColumn {
+    protected $column_name;
+
+	const EMAIL_SUBJECT_BASE64_ENCODED = '=?utf-8?B?';
+	const EMAIL_SUBJECT_QUOTED_ENCODED = '=?utf-8?Q?';
+
+    /**
+     * GenericColumn constructor.
+     * @param $column_name
+     */
+    public function __construct($column_name) {
+        $this->column_name = $column_name;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function render(array $mailArray, $format) {
+        if( ! array_key_exists($this->column_name, $mailArray) ) {
+            throw new ColumnDoesntExistException($this->column_name);
+        }
+
+        $subject = $mailArray[$this->column_name];
+
+		if( 0 === strpos($subject, self::EMAIL_SUBJECT_BASE64_ENCODED)) {
+			$subject_encoded = substr($subject, strlen(self::EMAIL_SUBJECT_BASE64_ENCODED), strlen($subject) - strlen(self::EMAIL_SUBJECT_BASE64_ENCODED) - 1);
+			$subject_decoded = base64_decode($subject_encoded);
+			return '[Base64] ' . $subject_decoded;
+		} else if ( 0 === strpos($subject, self::EMAIL_SUBJECT_QUOTED_ENCODED) ){
+			$subject_encoded = substr($subject, strlen(self::EMAIL_SUBJECT_QUOTED_ENCODED), strlen($subject) - strlen(self::EMAIL_SUBJECT_QUOTED_ENCODED) - 1);
+			$subject_decoded = quoted_printable_decode($subject_encoded);
+			return '[Quoted Printable] ' . $subject_decoded;
+		}
+		return $subject;
+    }
+}

--- a/src/Renderer/WPML_ColumnManager.php
+++ b/src/Renderer/WPML_ColumnManager.php
@@ -6,6 +6,7 @@ use No3x\WPML\Renderer\Column\AttachmentsColumn;
 use No3x\WPML\Renderer\Column\ErrorColumn;
 use No3x\WPML\Renderer\Column\GenericColumn;
 use No3x\WPML\Renderer\Column\IColumn;
+use No3x\WPML\Renderer\Column\SubjectColumn;
 use No3x\WPML\Renderer\Column\TimestampColumn;
 
 class WPML_ColumnManager {
@@ -53,6 +54,8 @@ class WPML_ColumnManager {
                 return new AttachmentsColumn();
             case self::COLUMN_ERROR:
                 return new ErrorColumn();
+            case self::COLUMN_SUBJECT:
+                return new SubjectColumn($column_name);
             default:
                 return new GenericColumn($column_name);
         }

--- a/tests/phpunit/unit/WPML_ColumnManager_Test.php
+++ b/tests/phpunit/unit/WPML_ColumnManager_Test.php
@@ -69,6 +69,23 @@ class WPML_ColumnManager_Test extends \PHPUnit_Framework_TestCase {
         $this->assertEquals('2018-09-24 16:02:11', $actual);
     }
 
+    public function test_column_subject_default() {
+        $actual = $this->columnManager->getColumnRenderer(WPML_ColumnManager::COLUMN_SUBJECT)->render($this->item, ColumnFormat::FULL);
+        $this->assertEquals('Test', $actual);
+    }
+
+    public function test_column_subject_base64() {
+        $this->item['subject'] = '=?UTF8?B?=' . base64_encode('Test') . '=';
+        $actual = $this->columnManager->getColumnRenderer(WPML_ColumnManager::COLUMN_SUBJECT)->render($this->item, ColumnFormat::FULL);
+        $this->assertEquals('[Base64] Test', $actual);
+    }
+
+    public function test_column_subject_quoted_printable() {
+        $this->item['subject'] = '=?UTF8?Q?=' . quoted_printable_encode('Test') . '=';
+        $actual = $this->columnManager->getColumnRenderer(WPML_ColumnManager::COLUMN_SUBJECT)->render($this->item, ColumnFormat::FULL);
+        $this->assertEquals('[Quoted] Test', $actual);
+    }
+
     public function test_column_attachments_simple() {
         $example1And2Expected = '/2018/05/file.pdf,\n/2018/01/bill.pdf';
         $actual = $this->columnManager->getColumnRenderer(WPML_ColumnManager::COLUMN_ATTACHMENTS)->render($this->item, ColumnFormat::SIMPLE);


### PR DESCRIPTION
Fixes #146

#### Description

This PR will add support for displaying base64 and quoted printable encoded subjects in the mall log table. 

Howto: https://ncona.com/2011/06/using-utf-8-characters-on-an-e-mail-subject/
RFC: https://datatracker.ietf.org/doc/html/rfc1342

#### Testing instructions

* Automated tests shall pass.
* Try to send an email containing an encoded subject, like described in the above "howto" link.
* Check if the string is displayed correctly in the mail log table.
* Check if the string has a "Base64" or "Quoted" prefix, matching with the subject encoding 

> *Note:* Couldn't install/run the unit tests myself, if you can run it, it'll be perfect.