### PR TITLE
Hide unrelated notices on admin plugin pages

### DIFF
--- a/src/WPML_Plugin.php
+++ b/src/WPML_Plugin.php
@@ -289,6 +289,9 @@ class WPML_Plugin extends WPML_LifeCycle implements IHooks {
             return;
         }
 
+        // Hide all unrelated to the plugin notices on the plugin admin pages.
+        add_action( 'admin_print_scripts', [ $this, 'hide_unrelated_notices' ] );
+
         $tab = filter_input( INPUT_GET, 'tab' );
 
         switch ( $tab ) {
@@ -308,6 +311,46 @@ class WPML_Plugin extends WPML_LifeCycle implements IHooks {
         }
 
         $tabObj->screen_hooks();
+    }
+
+    /**
+     * Remove all non-WP Mail Logging plugin notices from our plugin pages.
+     *
+     * @since {VERSION}
+     */
+    public function hide_unrelated_notices() {
+
+        $this->remove_unrelated_actions( 'user_admin_notices' );
+        $this->remove_unrelated_actions( 'admin_notices' );
+        $this->remove_unrelated_actions( 'all_admin_notices' );
+        $this->remove_unrelated_actions( 'network_admin_notices' );
+    }
+
+    /**
+     * Remove all non-WP Mail Logging notices from the our plugin pages based on the provided action hook.
+     *
+     * @since {VERSION}
+     *
+     * @param string $action The name of the action.
+     */
+    private function remove_unrelated_actions( $action ) {
+
+        global $wp_filter;
+
+        if ( empty( $wp_filter[ $action ]->callbacks ) || ! is_array( $wp_filter[ $action ]->callbacks ) ) {
+            return;
+        }
+
+        foreach ( $wp_filter[ $action ]->callbacks as $priority => $hooks ) {
+            foreach ( $hooks as $name => $arr ) {
+
+                if ( strpos( strtolower( $name ), 'no3x\wpml' ) !== false ) {
+                    continue;
+                }
+
+                unset( $wp_filter[ $action ]->callbacks[ $priority ][ $name ] );
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
## Description

This PR hides unrelated notices on WP Mail Logging admin pages.

## Testing procedure

1. Make sure you're using the `master` branch. `git checkout master`.
2. In your Local, install an outdated version of WordPress (even just 1 minor version back), just enough to show the upgrade notice in the Dashboard.
3. Navigate to Dashboard -> WP Mail Logging -> Email Log (or any other WP Mail Logging page). You should see the update WordPress notice

<img width="1568" alt="Screen Shot 2023-03-31 at 19 59 51" src="https://user-images.githubusercontent.com/5747475/229114937-de0d95b5-76cd-4ee3-a817-0535d87302b6.png">

4. Checkout this PR branch.
5. Refresh the page. You shouldn't see the upgrade notice anymore.