### PR TITLE
Fix MySQL 8 syntax error

### DIFF
--- a/src/WPML_InstallIndicator.php
+++ b/src/WPML_InstallIndicator.php
@@ -44,8 +44,13 @@ class WPML_InstallIndicator extends WPML_OptionsManager {
         if (!$installed) {
             global $wpdb;
 
-            $mails = $this->getTablename('mails');
-            $query = $wpdb->query("SHOW TABLES LIKE \"$mails\"");
+            $query = $wpdb->query(
+                $wpdb->prepare(
+                    "SHOW TABLES LIKE %s",
+                    $this->getTablename( 'mails' )
+                )
+            );
+
             $installed = (bool) $query;
 
             if ($installed) {


### PR DESCRIPTION
## Description

This PR fixes the syntax error when using MySQL 8 with `sql-mode = ANSI_QUOTES`. This is the error:
```
WordPress database error You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '"wp_wpml_mails"' at line 1 for query SHOW TABLES LIKE "wp_wpml_mails" made by require_once('wp-admin/admin.php'), require_once('wp-load.php'), require_once('wp-config.php'), require_once('wp-settings.php'), include_once('/plugins/wp-mail-logging/wp-mail-logging.php'), No3x\WPML\WPML_Init->init, No3x\WPML\WPML_InstallIndicator->isInstalled
```

## Testing procedure

1. Make sure your WP site is running on MySQL 8 with `sql-mode = ANSI_QUOTES`. You can do this by editing your MySQL's `.cnf`.

```
[mysqld]

sql-mode = ANSI_QUOTES
```

2. [Enable debugging in your WordPress](https://wordpress.org/documentation/article/debugging-in-wordpress/#example-wp-config-php-for-debugging).
3. Activate the WP Mail Logging plugin.
4. You shouldn't see the error in `debug.log`.