### PR TITLE
UTF8 encoded subjects

### DIFF
--- a/src/Renderer/Column/SubjectColumn.php
+++ b/src/Renderer/Column/SubjectColumn.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace No3x\WPML\Renderer\Column;
+
+use No3x\WPML\Renderer\Exception\ColumnDoesntExistException;
+use No3x\WPML\Renderer\WPML_ColumnManager;
+
+class SubjectColumn extends GenericColumn {
+
+    protected $subject = '';
+
+    const EMAIL_SUBJECT_BASE64_ENCODED = '=?utf-8?B?';
+    const EMAIL_SUBJECT_QUOTED_ENCODED = '=?utf-8?Q?';
+
+    public function __construct() {
+
+        parent::__construct( WPML_ColumnManager::COLUMN_SUBJECT );
+    }
+
+    /**
+     * @inerhitDoc
+     *
+     * @since {VERSION}
+     */
+    public function render( $item, $column_format ) {
+
+        if ( ! array_key_exists( $this->column_name, $item ) ) {
+            throw new ColumnDoesntExistException($this->column_name);
+        }
+
+        if ( empty( $item[ $this->column_name ] ) ) {
+            return '';
+        }
+
+        $this->subject = $item[ $this->column_name ];
+
+        if ( strpos( $this->subject, self::EMAIL_SUBJECT_BASE64_ENCODED ) === 0 ) {
+            return base64_decode( $this->get_encoded_subject( self::EMAIL_SUBJECT_BASE64_ENCODED ) );
+        }
+
+        if ( strpos( $this->subject, self::EMAIL_SUBJECT_QUOTED_ENCODED ) === 0 ) {
+            return quoted_printable_decode( $this->get_encoded_subject( self::EMAIL_SUBJECT_QUOTED_ENCODED ) );
+        }
+
+        return $this->subject;
+    }
+
+    /**
+     * Get the encoded part from the subject string.
+     *
+     * @since {VERSION}
+     *
+     * @param string $encode Type of encoding used in the subject.
+     *
+     * @return false|string
+     */
+    private function get_encoded_subject( $encode ) {
+
+        $encode_len      = strlen( $encode );
+        $encoded_subject = substr( $this->subject, $encode_len, strlen( $this->subject ) - $encode_len - 1 );
+
+        return $encoded_subject;
+    }
+}

--- a/src/Renderer/Column/SubjectColumn.php
+++ b/src/Renderer/Column/SubjectColumn.php
@@ -7,10 +7,32 @@ use No3x\WPML\Renderer\WPML_ColumnManager;
 
 class SubjectColumn extends GenericColumn {
 
-    protected $subject = '';
-
+    /**
+     * Base64 encoding prefix.
+     *
+     * @since {VERSION}
+     *
+     * @var string
+     */
     const EMAIL_SUBJECT_BASE64_ENCODED = '=?utf-8?B?';
+
+    /**
+     * Quoted-printable encoding prefix.
+     *
+     * @since {VERSION}
+     *
+     * @var string
+     */
     const EMAIL_SUBJECT_QUOTED_ENCODED = '=?utf-8?Q?';
+
+    /**
+     * The email subject.
+     *
+     * @since {VERSION}
+     *
+     * @var string
+     */
+    protected $subject = '';
 
     public function __construct() {
 

--- a/src/Renderer/Format/BaseRenderer.php
+++ b/src/Renderer/Format/BaseRenderer.php
@@ -8,7 +8,9 @@ use No3x\WPML\Admin\SettingsTab;
 use No3x\WPML\Admin\SMTPTab;
 use No3x\WPML\Renderer\Column\AttachmentsColumn;
 use No3x\WPML\Renderer\Column\ColumnFormat;
+use No3x\WPML\Renderer\Column\SubjectColumn;
 use No3x\WPML\Renderer\WPML_ColumnManager;
+use No3x\WPML\Renderer\WPML_MailRenderer;
 use No3x\WPML\WPML_Utils;
 
 abstract class BaseRenderer implements IMailRenderer {
@@ -146,6 +148,7 @@ abstract class BaseRenderer implements IMailRenderer {
      * Render the value.
      *
      * @since 1.11.0
+     * @since {VERSION}
      *
      * @param string $key   Key of the value to render.
      * @param string $value Value to be rendered.
@@ -153,9 +156,21 @@ abstract class BaseRenderer implements IMailRenderer {
      * @return void
      */
     private function render_column_value( $key, $value ) {
+        $format = empty( $_POST['format'] ) ? 'html' : $_POST['format'];
         ?>
         <div class="wp-mail-logging-modal-row-value wp-mail-logging-modal-row-value-<?php echo esc_attr( $key ); ?>">
             <?php
+
+            if ( $key === WPML_ColumnManager::COLUMN_SUBJECT && $format === WPML_MailRenderer::FORMAT_HTML ) {
+                try {
+                    $value = ( new SubjectColumn() )->render(
+                    [
+                        'subject' => $value,
+                    ],
+                    ColumnFormat::SIMPLE
+                );
+                } catch ( \Exception $e ) {}
+            }
 
             echo wp_kses_post( $value );
 

--- a/src/Renderer/WPML_ColumnManager.php
+++ b/src/Renderer/WPML_ColumnManager.php
@@ -7,6 +7,7 @@ use No3x\WPML\Renderer\Column\AttachmentsColumn;
 use No3x\WPML\Renderer\Column\ErrorColumn;
 use No3x\WPML\Renderer\Column\GenericColumn;
 use No3x\WPML\Renderer\Column\IColumn;
+use No3x\WPML\Renderer\Column\SubjectColumn;
 use No3x\WPML\Renderer\Column\TimestampColumn;
 
 class WPML_ColumnManager {
@@ -51,6 +52,8 @@ class WPML_ColumnManager {
                 return new AttachmentsColumn();
             case self::COLUMN_ERROR:
                 return new ErrorColumn();
+            case self::COLUMN_SUBJECT:
+                return new SubjectColumn();
             default:
                 return new GenericColumn($column_name);
         }


### PR DESCRIPTION
## Description

This PR adds the ability to support UTF8-encoded subjects in the email logs table

## Testing Procedure

1. Submit an email using `wp_mail()` with subject containing non ASCII characters. You can use the snippet below.
```php
add_action( 'init', function () {
	$to      = 'donmhico+test1@gmail.com';
	$subject = 'Subject with non ASCII ó¿¡á';
	$message = 'Message with non ASCII ó¿¡á';
	$headers = 'From: example@example.com'."\r\n"
	.'Content-Type: text/plain; charset=utf-8'."\r\n";

	wp_mail(
		$to,
		'=?utf-8?B?'. base64_encode( $subject ) . '?=',
		$message,
		$headers
	);
} );
```
2. Check WP Mail Logging's Email Logs. You should see the subject displaying properly.

<img width="811" alt="Screen Shot 2023-05-04 at 17 17 51" src="https://user-images.githubusercontent.com/5747475/236162718-4a6ac976-1ae9-4fa5-b35c-0e62ae4f95ac.png">

If you see the log details, you should also see this in HTML tab.

<img width="688" alt="Screen Shot 2023-05-04 at 17 19 29" src="https://user-images.githubusercontent.com/5747475/236163199-24e54aba-c3cb-4237-860d-6252a363b5de.png">

However, you should see the actual encoded subject in both `RAW` and `JSON` tab.