### PR TITLE
Fix: Missing Security Checks for AJAX Accessible Functions

### DIFF
--- a/src/WPML_Plugin.php
+++ b/src/WPML_Plugin.php
@@ -348,6 +348,15 @@ class WPML_Plugin extends WPML_LifeCycle implements IHooks {
                     continue;
                 }
 
+                // Handle the case when the callback is an array.
+                if (
+                    is_array( $arr ) && ! empty( $arr['function'] ) && is_array( $arr['function'] )
+                    && ! empty( $arr['function'][0] ) && is_object( $arr['function'][0] )
+                    && ( strpos( strtolower( get_class( $arr['function'][0] ) ), 'no3x\wpml' ) !== false )
+                ) {
+                    continue;
+                }
+
                 unset( $wp_filter[ $action ]->callbacks[ $priority ][ $name ] );
             }
         }

--- a/src/WPML_ProductEducation.php
+++ b/src/WPML_ProductEducation.php
@@ -64,7 +64,7 @@ class WPML_ProductEducation {
 
         check_ajax_referer( self::DISMISS_NONCE_ACTION, 'nonce' );
 
-        if ( empty( $_POST['productEducationID'] ) ) {
+        if ( empty( $_POST['productEducationID'] || ! is_super_admin() ) ) {
 
             wp_send_json_error(
                 esc_html__( 'Request invalid.', 'wp-mail-logging' )

--- a/src/WPML_UserFeedback.php
+++ b/src/WPML_UserFeedback.php
@@ -15,6 +15,15 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 class WPML_UserFeedback implements IHooks {
 
     /**
+     * The ajax action for notice dismissal.
+     *
+     * @since {VERSION}
+     *
+     * @var string
+     */
+    const AJAX_ACTION_NONCE = 'wp_mail_logging_user_feedback_notice_dismiss_nonce';
+
+    /**
      * The wp option for notice dismissal data.
      */
     const OPTION_NAME = 'wp_mail_logging_user_feedback_notice';
@@ -85,7 +94,7 @@ class WPML_UserFeedback implements IHooks {
         }
 
         ?>
-        <div class="notice notice-info is-dismissible wp-mail-logging-review-notice">
+        <div class="notice notice-info is-dismissible wp-mail-logging-review-notice" data-nonce="<?php echo esc_attr( wp_create_nonce( self::AJAX_ACTION_NONCE ) ); ?>">
             <div class="wp-mail-logging-review-step wp-mail-logging-review-step-1">
                 <p><?php esc_html_e( 'Are you enjoying WP Mail Logging?', 'wp-mail-logging' ); ?></p>
                 <p>
@@ -129,10 +138,25 @@ class WPML_UserFeedback implements IHooks {
         <script type="text/javascript">
             jQuery( document ).ready( function( $ ) {
                 $( document ).on( 'click', '.wp-mail-logging-dismiss-review-notice, .wp-mail-logging-review-notice button', function( e ) {
+
+                    var $parent = $( this ).parent( '.wp-mail-logging-review-notice' );
+
+                    if ( $parent.length <= 0 || ! $parent.data( 'nonce' ) ) {
+                        return;
+                    }
+
                     if (! $( this ).hasClass( 'wp-mail-logging-review-out' )) {
                         e.preventDefault();
                     }
-                    $.post( ajaxurl, {action: 'wp_mail_logging_feedback_notice_dismiss'} );
+
+                    $.post(
+                        ajaxurl,
+                        {
+                            action: 'wp_mail_logging_feedback_notice_dismiss',
+                            nonce: $parent.data( 'nonce' )
+                        }
+                    );
+
                     $( '.wp-mail-logging-review-notice' ).remove();
                 } );
 
@@ -161,13 +185,17 @@ class WPML_UserFeedback implements IHooks {
      */
     public function feedback_notice_dismiss() {
 
+        if ( empty( $_POST['nonce'] ) || ! check_admin_referer( self::AJAX_ACTION_NONCE, 'nonce' ) || ! is_super_admin() ) {
+            wp_send_json_error();
+        }
+
         $options              = get_option( self::OPTION_NAME, [] );
         $options['time']      = time();
         $options['dismissed'] = true;
 
         update_option( self::OPTION_NAME, $options );
 
-        if ( is_super_admin() && is_multisite() ) {
+        if ( is_multisite() ) {
             $site_list = get_sites();
             foreach ( (array) $site_list as $site ) {
                 switch_to_blog( $site->blog_id );


### PR DESCRIPTION
## Description

This PR fixes the missing security checks in AJAX dismiss features.

## Motivation

Fixes #159.

## Testing Procedure

This PR affects 2 dismiss notice actions. Dismissing both should work as intended and shouldn't produce any issues or errors in the logs.

### Product Education Banners

<img width="1558" alt="Screen Shot 2023-05-04 at 20 08 00" src="https://user-images.githubusercontent.com/5747475/236199524-6cbfe1f3-2ae4-45ea-9c62-956c8a57fd5f.png">

### User Feedback Notice

<img width="1575" alt="Screen Shot 2023-05-04 at 20 21 01" src="https://user-images.githubusercontent.com/5747475/236202387-6bebd930-f654-4575-8cec-69e5e7cdfd44.png">

Follow these steps to see the User Feedback Notice:

1. Find and delete the option `wp_mail_logging_user_feedback_notice` in your `wp_options` table.
2. Then find the option `wp_mail_logging_activated_time` in your `wp_options`. It should have a timestamp value like `1483200175`. You can just subtract `1` in the second to the left value, in my case I updated the value to `1383200175`. This will simulate that the plugin was activated some time ago.
3. Make sure that your WP Mail Logging has at least `10` email logs.
