### PR TITLE
PHP Deprecated: Constant FILTER_SANITIZE_STRING

### DIFF
--- a/src/inc/Admin/SettingsTab.php
+++ b/src/inc/Admin/SettingsTab.php
@@ -118,7 +118,7 @@ class SettingsTab {
     public function save_settings() {
 
          // Check if we need to save data.
-        $data = filter_input( INPUT_POST, 'wp-mail-logging-setting', FILTER_SANITIZE_STRING, FILTER_REQUIRE_ARRAY );
+        $data = filter_input( INPUT_POST, 'wp-mail-logging-setting', FILTER_SANITIZE_FULL_SPECIAL_CHARS, FILTER_REQUIRE_ARRAY );
 
         if ( empty( $data ) || empty( $_POST[ self::SAVE_SETTINGS_NONCE_ACTION ] ) || ! wp_verify_nonce( $_POST[ self::SAVE_SETTINGS_NONCE_ACTION ], self::SAVE_SETTINGS_NONCE_ACTION ) ) {
             return;


### PR DESCRIPTION
## Description

This PR fixes the PHP Deprecated notice in PHP `8.1`.

## Motivation

Fixes #157.

## Testing procedure

1. Make sure your WordPress is running on PHP `8.1`.
2. [Enable debugging in your WordPress](https://wordpress.org/documentation/article/debugging-in-wordpress/#example-wp-config-php-for-debugging).
3. Navigate to your Dashboard -> WP Mail Logging -> Settings and hit the "Save" button.
4. Check your `debug.log` and you shouldn't see the deprecated notice.