### PR TITLE
Query executed on site load and cache expiration time adjustment

### DIFF
--- a/src/WPML_InstallIndicator.php
+++ b/src/WPML_InstallIndicator.php
@@ -36,27 +36,28 @@ class WPML_InstallIndicator extends WPML_OptionsManager {
      * @return bool indicating if the plugin is installed already
      */
     public function isInstalled() {
-        $installed = false;
 
-        // We don't use the cached value, only its presence.
-        // This is because we never cache not installed state.
-        wp_cache_get(self::CACHE_INSTALLED_KEY, self::CACHE_GROUP, false, $installed);
-        if (!$installed) {
-            global $wpdb;
+        $installed = (bool) get_transient( self::CACHE_GROUP . '_' . self::CACHE_INSTALLED_KEY );
 
-            $query = $wpdb->query(
-                $wpdb->prepare(
-                    "SHOW TABLES LIKE %s",
-                    $this->getTablename( 'mails' )
-                )
-            );
-
-            $installed = (bool) $query;
-
-            if ($installed) {
-                wp_cache_set(self::CACHE_INSTALLED_KEY, true, self::CACHE_GROUP, 3600);
-            }
+        if ( $installed ) {
+            return true;
         }
+
+        global $wpdb;
+
+        $query = $wpdb->query(
+            $wpdb->prepare(
+                "SHOW TABLES LIKE %s",
+                $this->getTablename( 'mails' )
+            )
+        );
+
+        $installed = (bool) $query;
+
+        if ( $installed ) {
+            set_transient( self::CACHE_GROUP . '_' . self::CACHE_INSTALLED_KEY, true, 3600 );
+        }
+
         return $installed;
     }
 

--- a/src/WPML_UserFeedback.php
+++ b/src/WPML_UserFeedback.php
@@ -24,6 +24,15 @@ class WPML_UserFeedback implements IHooks {
     const AJAX_ACTION_NONCE = 'wp_mail_logging_user_feedback_notice_dismiss_nonce';
 
     /**
+     * Transient key for mail logs count.
+     *
+     * @since {VERSION}
+     *
+     * @var string
+     */
+    const MAIL_LOGS_COUNT_TRANSIENT_KEY = 'wp_mail_logging_total_logs_count';
+
+    /**
      * The wp option for notice dismissal data.
      */
     const OPTION_NAME = 'wp_mail_logging_user_feedback_notice';
@@ -86,9 +95,14 @@ class WPML_UserFeedback implements IHooks {
             return;
         }
 
-        // Only display the notice if our plugin is being used (has at least 10 email logs).
-        $total_logs = Mail::query()->search( false )->find( true );
+        $total_logs = get_transient( self::MAIL_LOGS_COUNT_TRANSIENT_KEY );
 
+        if ( $total_logs === false ) {
+            $total_logs = Mail::query()->search( false )->find( true );
+            set_transient( self::MAIL_LOGS_COUNT_TRANSIENT_KEY, absint( $total_logs ), DAY_IN_SECONDS );
+        }
+
+        // Only display the notice if our plugin is being used (has at least 10 email logs).
         if ( $total_logs < 10 ) {
             return;
         }


### PR DESCRIPTION
## Description

This PR replaces the usage of `wp_cache_get` and `wp_cache_set` to use `get_transient` / `set_transient` to make sure we are caching certain DB queries and not doing DB calls on each page load.

## Motivation

Fixes #150.

## Testing procedure

1. Install [Query Monitor](https://wordpress.org/plugins/query-monitor/) plugin in your WordPress.
2. Check the query calls.
3. You should no longer see the query `SHOW TABLES LIKE %s` being called on each page load.