### PR TITLE
Logger breaks if no array passed from wp_mail

### DIFF
--- a/src/WPML_Plugin.php
+++ b/src/WPML_Plugin.php
@@ -380,12 +380,21 @@ class WPML_Plugin extends WPML_LifeCycle implements IHooks {
     /**
      * Logs mail to database.
      *
-     * @param array $mailArray
      * @global $wpml_current_mail_id
+     *
+     * @param array $mailArray
+     *
      * @since 1.0
+     * @since {VERSION} Short-circuit if $mailArray is not an array.
+     *
      * @return array $mailOriginal
      */
     public function log_email( $mailArray ) {
+
+        if ( ! is_array( $mailArray ) ) {
+            return $mailArray;
+        }
+
         global $wpml_current_mail_id;
 
         $mail = (new WPML_MailExtractor())->extract($mailArray);


### PR DESCRIPTION
## Description

This PR fixes the issue where `wp_mail` triggers a fatal error if a non-array value is passed in `wp_mail` filter. In general, passing a `null` or non `array` value to `wp_mail` shouldn't be encouraged but such case should not trigger a fatal error just like how it works if WP Mail Logging plugin is not activated.

## Motivation

Fixes #94.

## Testing and procedure.

1. [Enable debugging logs](https://wordpress.org/documentation/article/debugging-in-wordpress/#example-wp-config-php-for-debugging).
2. Add this snippet to your `functions.php` or anywhere that it'll run.
```php
add_filter( 'wp_mail', function(){ return null; } );
```
3. Try to send an email.
4. You shouldn't see a new mail log on WP Mail Logging logs page but you should not also see a fatal error log.