### PR TITLE
Add line breaks to email previews

### DIFF
--- a/src/inc/Admin/EmailLogsTab.php
+++ b/src/inc/Admin/EmailLogsTab.php
@@ -128,7 +128,15 @@ class EmailLogsTab {
             return;
         }
 
-        echo $mail->get_message();
+        $message = $mail->get_message();
+
+        // Loosely test if the message is HTML.
+        if ( preg_match( '/<[a-z][^\s>\/]*>/i', $message ) ) {
+            echo $message;
+            exit;
+        }
+
+        echo nl2br( $message );
         exit;
     }
 


### PR DESCRIPTION
## Description

This PR fixes the issue where the line breaks on plain text (non-HTML) emails do not show in "HTML" preview. We solve this issue by loosely checking via regex if the message has any open tags `<>`. We are doing it this way because the other approaches I can think of are not good.

1. Check if the headers contains `Content-Type: text/html` - this won't work because some emails are not sent with this header but are still HMTL.
2. Use a proper HTML/DOM library to test if the message content is a valid HTML - while this will work, I believe it will be overkill and will be another overhead.

So the solution in this PR is to just check if any open tags are present. If yes, then it will assume that the message is an HTML and won't perform `nl2br()` to the message.

## Motivation

Fixes #158.

## Testing and procedure

1. Install [WP Mail SMTP](https://wordpress.org/plugins/wp-mail-smtp/) (will just be using this to send a test email).
4. Navigate to Dashboard -> WP Mail SMTP -> Tools -> Email Test, toggle off "HTML" and send the test email. https://a.supportally.com/i/p7qT9y
5. Navigate to Dashboard -> WP Mail Logging -> Email Log and view the sent test email. https://a.supportally.com/i/MU3GfB
6. View the log in both "HTML" and "Raw", you should see the line breaks on both. https://a.supportally.com/i/fgeohz

## Screenshot

https://a.supportally.com/i/eQowJS