### PR TITLE
User capability and settings visibility issue

### DIFF
--- a/src/WPML_OptionsManager.php
+++ b/src/WPML_OptionsManager.php
@@ -409,6 +409,10 @@ class WPML_OptionsManager {
             $menu_slug
         );
 
+        if ( ! current_user_can( WPML_Plugin::get_view_settings_capability() ) ) {
+            return;
+        }
+
         add_submenu_page( $menu_slug,
             __( 'Settings', 'wp-mail-logging' ),
             __( 'Settings', 'wp-mail-logging' ),


### PR DESCRIPTION
## Description

This PR fixes the issue where non-admin users can see the "Settings" and "SMTP" pages if they are allowed to see the email logs.

## Motivation

Fixes #169.

## Testing Procedure

1. Navigate to your Dashboard -> WP Mail Logging -> Settings, and set "Can See Submission data" to "Level 0". https://a.supportally.com/i/pEWPlc
2. Create a new user with a "subscriber" role.
3. Login to your Dashboard as the new subscriber user.
4. Navigate to Dashboard -> WP Mail Logging. You should not see and not be able to access "Settings" and "SMTP" pages. https://a.supportally.com/i/5Hkx47