### PR TITLE
Add a new filter before saving the mail log

### DIFF
--- a/src/WPML_Plugin.php
+++ b/src/WPML_Plugin.php
@@ -428,6 +428,15 @@ class WPML_Plugin extends WPML_LifeCycle implements IHooks {
 
         global $wpml_current_mail_id;
 
+        /**
+         * Filters mail data before it is logged.
+         *
+         * @since {VERSION}
+         *
+         * @param array $mailArray Array containing the mail data to be logged.
+         */
+        $mailArray = apply_filters( 'wp_mail_logging_before_log_email', $mailArray );
+
         $mail = (new WPML_MailExtractor())->extract($mailArray);
         $mail->set_plugin_version($this->getVersionSaved());
         $mail->set_timestamp(current_time( 'mysql' ));


### PR DESCRIPTION
## Description

This PR adds a new filter named, `wp_mail_logging_before_log_email` which passed the `$mailArray` (an array containing the mail data) before it's saved.

This will give the developers the ability to manipulate the mail data before it's saved. One such use case is to remove sensitive data as described in #124.

## Testing procedure

1. Add this snippet in your `functions.php` or anywhere where it will run.

```php
function before_log_email( $mail ) {

	$mail['to'] = 'john.doe@test.com';
	$mail['message'] = 'This is a test';
	$mail['subject'] = 'Lorem';

	return $mail;
}
```

2. Trigger an email send in your WordPress that WP Mail Logging will capture/
3. Check the Email Logs. You should notice that the email saved contains the data that we manipulated instead of the original data.