### PR TITLE
Escape the subject

### DIFF
--- a/src/Renderer/Column/SubjectColumn.php
+++ b/src/Renderer/Column/SubjectColumn.php
@@ -64,7 +64,7 @@ class SubjectColumn extends GenericColumn {
             return quoted_printable_decode( $this->get_encoded_subject( self::EMAIL_SUBJECT_QUOTED_ENCODED ) );
         }
 
-        return $this->subject;
+        return esc_html( $this->subject );
     }
 
     /**

--- a/src/Renderer/Format/BaseRenderer.php
+++ b/src/Renderer/Format/BaseRenderer.php
@@ -172,7 +172,11 @@ abstract class BaseRenderer implements IMailRenderer {
                 } catch ( \Exception $e ) {}
             }
 
-            echo wp_kses_post( $value );
+            if ( $key === WPML_ColumnManager::COLUMN_SUBJECT ) {
+                echo esc_html( $value );
+            } else {
+                echo wp_kses_post( $value );
+            }
 
             if ( $key === 'error' ) {
                 ?>


### PR DESCRIPTION
## Description

This PR fixes the issue where the Subject renders HTML such as `<img>` tag and other HTML tags that are allowed in  `wp_kses_post()`

## Testing procedure

1. Send an email thru your WordPress (using `wp_mail()`) with the subject containing `<img>` tag.
2. Navigate to your Dashboard -> WP Mail Logging -> Email Logs. You should see the string literal of the `<img` tag instead of the browser actually rendering the image.

## Screenshots

<img width="1086" alt="Screen Shot 2023-06-19 at 17 04 56" src="https://github.com/awesomemotive/wp-mail-logging/assets/5747475/79309ffd-a8c8-4c72-a9b1-c4d5a153c16b">

<img width="697" alt="Screen Shot 2023-06-19 at 17 05 56" src="https://github.com/awesomemotive/wp-mail-logging/assets/5747475/a1f74693-c3f2-4d93-8a49-e023089a4887">
