### PR TITLE
Always allow admins to access the email logs

### DIFF
--- a/src/Renderer/WPML_MailRenderer_AJAX_Handler.php
+++ b/src/Renderer/WPML_MailRenderer_AJAX_Handler.php
@@ -83,17 +83,17 @@ class WPML_MailRenderer_AJAX_Handler implements IHooks {
 
     /**
      * Handles the AJAX request for my plugin.
+     *
+     * @since {VERSION} Updated the user capability check.
      */
     public function handle() {
 
         $this->checkNonce();
 
-        $settings = SettingsTab::get_settings( SettingsTab::DEFAULT_SETTINGS );
-
-        if ( ! current_user_can( $settings['can-see-submission-data'] ) ) {
+        if ( ! WPML_Utils::can_current_user_access_wp_mail_logging_submissions() ) {
             wp_send_json_error( [
                 'code'    => self::ERROR_OTHER_CODE,
-                'message' => 'Invalid request!'
+                'message' => esc_html__( 'Invalid request!', 'wp-mail-logging' ),
             ] );
         }
 

--- a/src/WPML_Email_Log_List.php
+++ b/src/WPML_Email_Log_List.php
@@ -130,6 +130,7 @@ class WPML_Email_Log_List extends \WP_List_Table implements IHooks {
      * Process action the admin initiated.
      *
      * @since 1.11.0
+     * @since {VERSION} Updated the user capability check.
      *
      * @return void
      */
@@ -141,9 +142,7 @@ class WPML_Email_Log_List extends \WP_List_Table implements IHooks {
             return;
         }
 
-        $settings = SettingsTab::get_settings( SettingsTab::DEFAULT_SETTINGS );
-
-        if ( ! current_user_can( $settings['can-see-submission-data'] ) ) {
+        if ( ! WPML_Utils::can_current_user_access_wp_mail_logging_submissions() ) {
             return;
         }
 

--- a/src/WPML_OptionsManager.php
+++ b/src/WPML_OptionsManager.php
@@ -349,8 +349,7 @@ class WPML_OptionsManager {
 
         $pluginNameSlug = $this->getPluginSlug();
         $menu_slug      = $pluginNameSlug . '_log';
-
-        $capability = $this->getSetting( 'can-see-submission-data', 'manage_options' );
+        $capability     = 'manage_options';
 
         if ( ! empty( $this->getSetting( 'top-level-menu', '1' ) ) ) {
             $this->setup_top_level_menu( $capability, $menu_slug );
@@ -503,10 +502,18 @@ class WPML_OptionsManager {
         return $status;
     }
 
+    /**
+     * Show the log menu.
+     *
+     * @since 1.1.0
+     * @since {VERSION} Update the method used to check the user capabilities.
+     *
+     * @return void
+     */
     public function LogMenu() {
 
-        if ( !current_user_can( $this->getSetting( 'can-see-submission-data', 'manage_options' ) ) ) {
-            wp_die(__('You do not have sufficient permissions to access this page.', 'wp-mail-logging'));
+        if ( ! WPML_Utils::can_current_user_access_wp_mail_logging_submissions() ) {
+            wp_die( __( 'You do not have sufficient permissions to access this page.', 'wp-mail-logging' ) );
         }
 
         if (!class_exists( 'Email_Log_List_Table' ) ) {
@@ -543,7 +550,7 @@ class WPML_OptionsManager {
 
     public function _LogMenu() {
 
-        if ( ! current_user_can( $this->getSetting( 'can-see-submission-data', 'manage_options' ) ) ) {
+        if ( ! WPML_Utils::can_current_user_access_wp_mail_logging_submissions() ) {
             wp_die( __( 'You do not have sufficient permissions to access this page.', 'wp-mail-logging' ) );
         }
 

--- a/src/WPML_OptionsManager.php
+++ b/src/WPML_OptionsManager.php
@@ -351,6 +351,10 @@ class WPML_OptionsManager {
         $menu_slug      = $pluginNameSlug . '_log';
         $capability     = 'manage_options';
 
+        if ( ! current_user_can( 'manage_options' ) && current_user_can( $this->getSetting( 'can-see-submission-data', 'manage_options' ) ) ) {
+            $capability = $this->getSetting( 'can-see-submission-data', 'manage_options' );
+        }
+
         if ( ! empty( $this->getSetting( 'top-level-menu', '1' ) ) ) {
             $this->setup_top_level_menu( $capability, $menu_slug );
         } else {

--- a/src/WPML_Utils.php
+++ b/src/WPML_Utils.php
@@ -276,4 +276,20 @@ class WPML_Utils {
 
         return add_query_arg( 'page', self::ADMIN_PAGE_SLUG, $admin_base );
     }
+
+    /**
+     * Check if the current user can access the WP Mail Logging submissions.
+     *
+     * @since {VERSION}
+     *
+     * @return bool
+     *
+     * @throws \Exception If the service is not registered.
+     */
+    public static function can_current_user_access_wp_mail_logging_submissions() {
+
+        // Either an administrator or a user with the correct capability can see the submission data.
+        return current_user_can( 'administrator' ) ||
+            current_user_can( WPML_Init::getInstance()->getService( 'plugin' )->getSetting( 'can-see-submission-data', 'manage_options' ) );
+    }
 }

--- a/src/inc/Admin/EmailLogsTab.php
+++ b/src/inc/Admin/EmailLogsTab.php
@@ -121,9 +121,7 @@ class EmailLogsTab {
             return;
         }
 
-        $allowed_capability = WPML_Init::getInstance()->getService( 'plugin' )->getSetting( 'can-see-submission-data', 'manage_options' );
-
-        if ( ! current_user_can( $allowed_capability ) ) {
+        if ( ! WPML_Utils::can_current_user_access_wp_mail_logging_submissions() ) {
             return;
         }
 


### PR DESCRIPTION
### Description

This PR will always allow administrators, aside from the users with the selected capability, to access the email logs.

### Motivation

Fixes #185.

### Testing procedures

1. Navigate to your WP Dashboard -> WP Mail Logging -> Settings, and set "Can See Submission Data" to something other than `manage_options`. Set it to a capability that's explicitly not added to `administrator` role.
2. After saving, you should still be able to see all of the WP Mail Logging admin pages.
3. Login as the user with the capability you selected on step number 1, and you should also be able to see the WP Mail Logging pages.