### PR TITLE
Fix the issue 196 that produces warning messages on PHP 8

### DIFF
--- a/src/WPML_Plugin.php
+++ b/src/WPML_Plugin.php
@@ -583,8 +583,8 @@ class WPML_Plugin extends WPML_LifeCycle implements IHooks {
 
         $should_force_add_content_type = true;
 
-        for ( $ctr = 0; $ctr < count( $mail_headers ); $ctr++ ) {
-            $header_arr = explode( ":", $mail_headers[ $ctr ] );
+        foreach ( $mail_headers as $mail_header ) {
+            $header_arr = explode( ":", $mail_header );
 
             // If Content-Type header is already set, don't add it again.
             if ( ! empty( $header_arr[0] ) && strtolower( $header_arr[0] ) === 'content-type' ) {


### PR DESCRIPTION
This pull request fixes the issue #196, Always produce warning messages after Build v1.13.0 on PHP 8 by changing codes to access mail header values in foreach instead of retrieving them using index numbers in the for loop.