### PR TITLE
Function _load_textdomain_just_in_time was called incorrectly

### DIFF
--- a/wp-mail-logging.php
+++ b/wp-mail-logging.php
@@ -63,7 +63,7 @@ function WPML_i18n_init() {
 /////////////////////////////////
 
 // First initialize i18n
-WPML_i18n_init();
+add_action( 'init', __NAMESPACE__ .'\WPML_i18n_init' );
 
 
 // Next, run the version check.


### PR DESCRIPTION
### Description

This PR moves the invocation of the `load_textdomain()` to `init` hook.

### Motivation

Fixes #198.