### PR TITLE
PHP Error message: Uncaught TypeError: array_merge()

### DIFF
--- a/src/WPML_LifeCycle.php
+++ b/src/WPML_LifeCycle.php
@@ -202,7 +202,12 @@ class WPML_LifeCycle extends WPML_InstallIndicator {
         if ($this->getMainPluginFileName() == basename($plugin_file)) {
             $admin_url = add_query_arg( 'tab', 'settings', WPML_Utils::get_admin_page_url() );
             $settings  = array('settings' => '<a href="' . esc_url( $admin_url ) . '">' . __( 'Settings', 'wp-mail-logging' ) . '</a>' );
-            $actions   = array_merge($settings, $actions);
+
+            if ( ! is_array( $actions ) ) {
+                $actions = [];
+            }
+
+            $actions = array_merge( $settings, $actions );
         }
         return $actions;
     }


### PR DESCRIPTION
### Description

This PR fixes the issue where a PHP error happens in some cases.

### Motivation

Fixes #203.