### PR TITLE
Cannot use a scalar value as an array in WPML_MessageSanitizer

### DIFF
--- a/src/WPML_MessageSanitizer.php
+++ b/src/WPML_MessageSanitizer.php
@@ -48,6 +48,11 @@ class WPML_MessageSanitizer {
 
     private function stripEvilCode() {
         $allowed_tags = wp_kses_allowed_html( 'post' );
+
+        if ( ! is_array( $allowed_tags ) ) {
+            $allowed_tags = [];
+        }
+
         $allowed_tags['style'][''] = true;
         $allowed_tags[self::SAVED_COMMENT_HTMLEntity_OPEN][''] = true;
         $allowed_tags[self::SAVED_COMMENT_HTMLEntity_CLOSE][''] = true;


### PR DESCRIPTION
### Description

This PR makes sure that the variable `$allowed_tags` is an array to fix the PHP notice.

### Motivation

Fixes #187.

### Reference

See [wp.org issue here](https://wordpress.org/support/topic/getting-warning-on-plugin/#post-16990123).