### PR TITLE
Receiver format

### DIFF
--- a/src/Renderer/Column/GenericColumn.php
+++ b/src/Renderer/Column/GenericColumn.php
@@ -5,6 +5,7 @@ namespace No3x\WPML\Renderer\Column;
 use No3x\WPML\Renderer\Exception\ColumnDoesntExistException;
 
 class GenericColumn implements IColumn {
+
     protected $column_name;
 
     /**
@@ -24,5 +25,13 @@ class GenericColumn implements IColumn {
         }
 
         return $mailArray[$this->column_name];
+    }
+
+    /**
+     * @inheritdoc 
+     */
+    public function getColumnName() {
+
+        return $this->column_name;
     }
 }

--- a/src/Renderer/Column/SanitizedColumnDecorator.php
+++ b/src/Renderer/Column/SanitizedColumnDecorator.php
@@ -2,7 +2,7 @@
 
 namespace No3x\WPML\Renderer\Column;
 
-
+use No3x\WPML\Renderer\WPML_ColumnManager;
 use No3x\WPML\WPML_MessageSanitizer;
 
 class SanitizedColumnDecorator implements IColumn {
@@ -27,6 +27,14 @@ class SanitizedColumnDecorator implements IColumn {
      */
     public function render(array $mailArray, $format) {
         $delegated = $this->column->render($mailArray, $format);
+
+        if (
+            method_exists( $this->column, 'getColumnName' ) &&
+            $this->column->getColumnName() === WPML_ColumnManager::COLUMN_RECEIVER
+        ) {
+            return esc_html( $delegated );
+        }
+
         return $this->messageSanitizer->sanitize($delegated);
     }
 }

--- a/src/Renderer/Format/BaseRenderer.php
+++ b/src/Renderer/Format/BaseRenderer.php
@@ -172,7 +172,7 @@ abstract class BaseRenderer implements IMailRenderer {
                 } catch ( \Exception $e ) {}
             }
 
-            if ( $key === WPML_ColumnManager::COLUMN_SUBJECT ) {
+            if ( $key === WPML_ColumnManager::COLUMN_SUBJECT || $key === WPML_ColumnManager::COLUMN_RECEIVER ) {
                 echo esc_html( $value );
             } else {
                 echo wp_kses_post( $value );

--- a/src/Renderer/WPML_ColumnManager.php
+++ b/src/Renderer/WPML_ColumnManager.php
@@ -54,7 +54,7 @@ class WPML_ColumnManager {
      * @param $column_name
      * @return IColumn
      */
-    public function getColumnRenderer($column_name) {
+    public function getColumnRenderer( $column_name ) {
         switch ($column_name) {
             case self::COLUMN_TIMESTAMP:
                 return new TimestampColumn();

--- a/src/WPML_Email_Log_List.php
+++ b/src/WPML_Email_Log_List.php
@@ -734,7 +734,9 @@ class WPML_Email_Log_List extends \WP_List_Table implements IHooks {
             return $this->display_actions_icons( $item['mail_id'] );
         }
 
-        return ( new SanitizedColumnDecorator($this->columnManager->getColumnRenderer($column_name)))->render($item, ColumnFormat::FULL);
+        return ( new SanitizedColumnDecorator(
+            $this->columnManager->getColumnRenderer( $column_name )
+        ) )->render( $item, ColumnFormat::FULL );
     }
 
     /**


### PR DESCRIPTION
### Description

This PR allows the format "Name <email@domain.test>" to be displayed in both the log table and email log details.

### Motivation

Fixes #207.

### Testing procedures

1. Send an email using `wp_mail()` with `$to` in the format of "Name <email@domain.test>".
```php
// The recipient's name and email address.
$to = 'michael@doe.test';

// The subject of the email.
$subject = 'This is a test email';

// The body of the email.
$message = 'Hello Michael, this is just a test!';

// Send the email.
$sent = wp_mail( $to, $subject, $message );
```
2. Navigate to your WP Dashboard -> WP Mail Logging -> Email Log, you should see the full format in the "Receiver" column. https://a.supportally.com/i/cfTPml
3. View the email log detail, you should see the full format in the "Receiver" row. https://a.supportally.com/i/4nVwdK