### PR TITLE
Incorrect Headers format in modal row

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -112,6 +112,7 @@ Yes, you can contribute on <a href="https://github.com/awesomemotive/wp-mail-log
 Added: Support "Name <email@domain.test>" format on Receiver.
 Added: New filters `wp_mail_logging_allowed_html_email_html_preview` and `wp_mail_logging_allowed_protocols_email_html_preview`.
 Fixed: PHP Warning when JetPack plugin is also activated.
+Fixed: Incorrect Headers format in modal row.
 
 = 1.14.0 - 2024-12-26 =
 Fixed: PHP warning notice when another plugin or code snippet passed an associative array to `WPML_Plugin::get_mail_headers()`.

--- a/src/Renderer/Format/BaseRenderer.php
+++ b/src/Renderer/Format/BaseRenderer.php
@@ -149,7 +149,7 @@ abstract class BaseRenderer implements IMailRenderer {
      *
      * @since 1.11.0
      * @since 1.12.0
-     * @since {VERSION} Used `esc_html()` on `receiver` column.
+     * @since {VERSION} Used `esc_html()` on Subject, Receiver, and Headers columns.
      *
      * @param string $key   Key of the value to render.
      * @param string $value Value to be rendered.
@@ -173,7 +173,13 @@ abstract class BaseRenderer implements IMailRenderer {
                 } catch ( \Exception $e ) {}
             }
 
-            if ( $key === WPML_ColumnManager::COLUMN_SUBJECT || $key === WPML_ColumnManager::COLUMN_RECEIVER ) {
+            $values_to_escape = [
+                WPML_ColumnManager::COLUMN_SUBJECT,
+                WPML_ColumnManager::COLUMN_RECEIVER,
+                WPML_ColumnManager::COLUMN_HEADERS,
+            ];
+
+            if ( in_array( $key, $values_to_escape, true ) ) {
                 echo esc_html( $value );
             } else {
                 echo wp_kses_post( $value );


### PR DESCRIPTION
### Description

This PR fixes the issue where the Headers are incorrectly formatted when displayed in email log details modal.

### Motivation

Fixes #214.

### Testing procedures

1. Try to send an email with additional headers.
```php

// The recipient's name and email address.
$to = 'Michael Doe <michael@doe.test>';

// The subject of the email.
$subject = 'This is a test email';

// The body of the email.
$message = 'Hello World!';

$headers = [];
$headers[] = 'Reply-To: John Smith <john.smith@somesite.com>';

// Send the email.
$sent = wp_mail( $to, $subject, $message, $headers );
```
2. Navigate to Dashboard -> WP Mail Logging -> Email Log and view the email log details of the recently sent email. The Headers should be formatted correctly. https://a.supportally.com/i/b0gmjQ